### PR TITLE
set bdb to smaller free space reqs

### DIFF
--- a/commons/src/main/java/org/archive/util/bdbje/EnhancedEnvironment.java
+++ b/commons/src/main/java/org/archive/util/bdbje/EnhancedEnvironment.java
@@ -86,6 +86,7 @@ public class EnhancedEnvironment extends Environment {
      */
     public static EnhancedEnvironment getTestEnvironment(File dir) {
         EnvironmentConfig envConfig = new EnvironmentConfig();
+        envConfig.setConfigParam("je.freeDisk",String.valueOf(50*1024*1024));
         envConfig.setAllowCreate(true);
         envConfig.setTransactional(false);
         EnhancedEnvironment env;


### PR DESCRIPTION
This should allow us to run heritrix on instances with smaller storage disks.

https://docs.oracle.com/cd/E17277_02/html/java/com/sleepycat/je/EnvironmentConfig.html