### PR TITLE
set bdb free_disk value to 0 (ignore)

### DIFF
--- a/commons/src/main/java/org/archive/bdb/BdbModule.java
+++ b/commons/src/main/java/org/archive/bdb/BdbModule.java
@@ -255,6 +255,7 @@ public class BdbModule implements Lifecycle, Checkpointable, Closeable, Disposab
     throws DatabaseException, IOException {
         EnvironmentConfig config = new EnvironmentConfig();
         config.setAllowCreate(create);
+        config.setConfigParam(EnvironmentConfig.FREE_DISK, "0");
         config.setLockTimeout(75, TimeUnit.MINUTES); // set to max
 
         if (getCacheSize() > 0) {


### PR DESCRIPTION
Tested locally on macOS using a flash disk partitioned with <3GB of space as HERITRIX_HOME